### PR TITLE
Add capi to plink

### DIFF
--- a/cert/cert_common.h
+++ b/cert/cert_common.h
@@ -20,7 +20,7 @@
 
 // functions used only by the capi and pkcs addon modules
 EXTERN void cert_reverse_array(LPBYTE pb, DWORD cb);
-EXTERN void cert_prompt_cert(HCERTSTORE hStore, HWND hWnd, LPSTR * szCert, LPCSTR szIden, LPCSTR szHint);
+EXTERN void cert_prompt_cert(HCERTSTORE hStore, HWND hWnd, LPSTR * szCert, LPCSTR szIden, LPCSTR szHint, bool takeFirst);
 EXTERN BOOL cert_load_cert(LPCSTR szCert, PCERT_CONTEXT * ppCertContext, HCERTSTORE * phCertStore);
 EXTERN LPSTR cert_get_cert_hash(LPCSTR szIden, PCCERT_CONTEXT pCertContext, LPCSTR szHint);
 EXTERN PVOID cert_pin(LPSTR szCert, BOOL bUnicode, LPVOID szPin, HWND hWnd);
@@ -32,7 +32,7 @@ EXTERN BOOL cert_ignore_expired_certs(DWORD bEnable);
 // functions used by putty code 
 EXTERN LPSTR cert_key_string(LPCSTR szCert);
 EXTERN LPSTR cert_subject_string(LPCSTR szCert);
-EXTERN LPSTR cert_prompt(LPCSTR szIden, HWND hWnd);
+EXTERN LPSTR cert_prompt(LPCSTR szIden, HWND hWnd, bool takeFirst);
 EXTERN LPBYTE cert_sign(struct ssh2_userkey * userkey, LPCBYTE pDataToSign, int iDataToSignLen, int * iWrappedSigLen, HWND hWnd);
 EXTERN struct ssh2_userkey * cert_load_key(LPCSTR szCert);
 EXTERN VOID cert_display_cert(LPCSTR szCert, HWND hWnd);

--- a/cmdline.c
+++ b/cmdline.c
@@ -853,6 +853,15 @@ int cmdline_process_param(const char *p, char *value,
     }
 #endif
 
+	if (!strcmp(p, "-capi") ||
+		!strcmp(p, "-CAPI")) {
+		RETURN(1);
+		UNAVAILABLE_IN(TOOLTYPE_FILETRANSFER | TOOLTYPE_NONNETWORK);
+		SAVEABLE(0);
+		conf_set_str(conf, CONF_cert_certid, "Read from current Smart Card");
+		conf_set_bool(conf, CONF_try_cert_auth, true);
+	}
+
     return ret;			       /* unrecognised */
 }
 

--- a/config.c
+++ b/config.c
@@ -694,7 +694,7 @@ void cert_event_handler(union control *ctrl, void *dlg, void *data, int event)
 	// handle capi certificate set button press
 	if (ctrl == certd->cert_set_capi_button && event == EVENT_ACTION)
 	{
-		char * szCert = cert_prompt(IDEN_CAPI, hwnd);
+		char * szCert = cert_prompt(IDEN_CAPI, hwnd, false);
 		if (szCert == NULL) return;
 		conf_set_str(conf, CONF_cert_certid, szCert);
 		conf_set_bool(conf, CONF_try_cert_auth, 1);
@@ -706,7 +706,7 @@ void cert_event_handler(union control *ctrl, void *dlg, void *data, int event)
 	// handle pkcs certificate set button press
 	if (ctrl == certd->cert_set_pkcs_button && event == EVENT_ACTION)
 	{
-		char * szCert = cert_prompt(IDEN_PKCS, hwnd);
+		char * szCert = cert_prompt(IDEN_PKCS, hwnd, false);
 		if (szCert == NULL) return;
 		conf_set_str(conf, CONF_cert_certid, szCert);
 		conf_set_bool(conf, CONF_try_cert_auth, 1);

--- a/puttymem.h
+++ b/puttymem.h
@@ -93,7 +93,7 @@ void safefree(void *);
  * the freed memory at the previous location.
  */
 void *safegrowarray(void *array, size_t *size, size_t eltsize,
-                    size_t oldlen, size_t extralen, bool private);
+                    size_t oldlen, size_t extralen, bool private1);
 
 /* The master macro wrapper, of which all others are special cases */
 #define sgrowarray_general(array, size, n, m, priv)                     \

--- a/windows/winpgnt.c
+++ b/windows/winpgnt.c
@@ -577,7 +577,7 @@ static INT_PTR CALLBACK KeyListProc(HWND hwnd, UINT msg,
 		  case IDC_PAGEANT_ADD_CAPI: /* add capi key */
 		  {
 			  char * szCert = cert_prompt((LOWORD(wParam) == IDC_PAGEANT_ADD_CAPI) ?
-				  (IDEN_CAPI) : (IDEN_PKCS), hwnd);
+				  (IDEN_CAPI) : (IDEN_PKCS), hwnd, false);
 			  if (szCert == NULL) return 0;
 			  Filename *fn = filename_from_str(szCert);
 			  char *err = NULL;
@@ -1160,7 +1160,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT message,
 			break;
 		}
 		char * szCert = cert_prompt(((wParam & ~0xF) == IDM_ADDCAPI) ?
-			(IDEN_CAPI) : (IDEN_PKCS), hwnd);
+			(IDEN_CAPI) : (IDEN_PKCS), hwnd, false);
 		if (szCert == NULL) break;
 		Filename *fn = filename_from_str(szCert);
 		char *err = NULL;

--- a/windows/winplink.c
+++ b/windows/winplink.c
@@ -12,6 +12,7 @@
 #include "storage.h"
 #include "tree234.h"
 #include "winsecur.h"
+#include "cert_common.h"
 
 #define WM_AGENT_CALLBACK (WM_APP + 4)
 
@@ -421,6 +422,17 @@ int main(int argc, char **argv)
 	fprintf(stderr, "Plink requires WinSock 2\n");
 	return 1;
     }
+
+#ifdef PUTTY_CAC
+	//Get CAPI info if needed
+	if (conf_get_bool(conf, CONF_try_cert_auth)) {
+		//Probably should set the takeFirst arguments as a command line argument
+		//But I wanted a way to automate logging in with CAPI without needing dialog box
+		char * szCert = cert_prompt(IDEN_CAPI, hwnd, true);
+		if (szCert == NULL) return;
+		conf_set_str(conf, CONF_cert_certid, szCert);
+	}
+#endif
 
     /*
      * Plink doesn't provide any way to add forwardings after the

--- a/windows/winstuff.h
+++ b/windows/winstuff.h
@@ -29,6 +29,7 @@
 #include "tree234.h"
 
 #include "winhelp.h"
+#include "commdlg.h"
 
 #if defined _M_IX86 || defined _M_AMD64
 #define BUILDINFO_PLATFORM "x86 Windows"


### PR DESCRIPTION
The biggest point of contention is the addition of takeFirst flag which allows plink to proceed with the first credential found on a smart card without letting or requiring the user to pick from the dialog box.

Also modified CertFindCertificateInStore to use CERT_FIND_EXT_ONLY_ENHKEY_USAGE_FLAG. This probably doesn't have to be hardcoded, but I couldn't figure out how to make this flag set true with the existing code.