### PR TITLE
Add initial support for sha2 agent signature algos

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,0 @@
-# EditorConfig is awesome: https://EditorConfig.org
-
-# top-most EditorConfig file
-root = true
-
-# Don't use tabs for indentation.
-[*]
-indent_style = tab

--- a/code/cert/cert_capi.h
+++ b/code/cert/cert_capi.h
@@ -19,7 +19,7 @@
 #endif
 
 // functions used by the common module
-EXTERN BYTE * cert_capi_sign(struct ssh2_userkey * userkey, LPCBYTE pDataToSign, int iDataToSignLen, int * iSigLen, HWND hWnd);
+EXTERN BYTE * cert_capi_sign(struct ssh2_userkey * userkey, LPCBYTE pDataToSign, int iDataToSignLen, int * iSigLen, HWND hWnd, uint32_t flags, const char ** sign_alg_name);
 EXTERN void cert_capi_load_cert(LPCSTR szCert, PCCERT_CONTEXT* ppCertCtx, HCERTSTORE* phStore);
 EXTERN HCERTSTORE cert_capi_get_cert_store(LPCSTR * szHint, HWND hWnd);
 

--- a/code/cert/cert_common.h
+++ b/code/cert/cert_common.h
@@ -33,7 +33,7 @@ EXTERN BOOL cert_ignore_expired_certs(DWORD bEnable);
 EXTERN LPSTR cert_key_string(LPCSTR szCert);
 EXTERN LPSTR cert_subject_string(LPCSTR szCert);
 EXTERN LPSTR cert_prompt(LPCSTR szIden, HWND hWnd, BOOL bAutoSelect);
-EXTERN LPBYTE cert_sign(struct ssh2_userkey * userkey, LPCBYTE pDataToSign, int iDataToSignLen, int * iWrappedSigLen, HWND hWnd);
+EXTERN LPBYTE cert_sign(struct ssh2_userkey * userkey, LPCBYTE pDataToSign, int iDataToSignLen, int * iWrappedSigLen, HWND hWnd, uint32_t flags);
 EXTERN struct ssh2_userkey * cert_load_key(LPCSTR szCert, HWND hWnd);
 EXTERN VOID cert_display_cert(LPCSTR szCert, HWND hWnd);
 EXTERN int cert_all_certs(LPSTR ** pszCert);

--- a/code/pageant.c
+++ b/code/pageant.c
@@ -367,7 +367,7 @@ void pageant_handle_msg(BinarySink *bs,
 		if (cert_is_certpath(key->comment))
 		{
 			DWORD siglen = 0;
-			LPBYTE sig = cert_sign(key, (LPCBYTE)sigdata.ptr, sigdata.len, &siglen, NULL);
+			LPBYTE sig = cert_sign(key, (LPCBYTE)sigdata.ptr, sigdata.len, &siglen, NULL, flags);
 			put_data(BinarySink_UPCAST(signature), sig, siglen);
 		}
 		else

--- a/code/ssh2userauth.c
+++ b/code/ssh2userauth.c
@@ -972,7 +972,7 @@ static void ssh2_userauth_process_queue(PacketProtocolLayer *ppl)
 					{
 						DWORD siglen = 0;
 						ptrlen datatosign = ptrlen_from_strbuf(sigdata);
-						LPBYTE sig = cert_sign(key, datatosign.ptr, datatosign.len, &siglen, hwnd);
+						LPBYTE sig = cert_sign(key, datatosign.ptr, datatosign.len, &siglen, hwnd, 0);
 						put_data(BinarySink_UPCAST(sigblob), sig, siglen);
 					}
 					else


### PR DESCRIPTION
* Adds initial support for sha2 agent signature algorithms.
  * This addresses #30 and #55 
* Adds editor config file so visual studio and other editors default to tabs as appears to be the convention in the codebase.
* Tested with putty private key (no regression), CAPI user certificate, CAPI smartcard certificate